### PR TITLE
add nap registration

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -6,6 +6,7 @@ ACTIVITIES = [
     "👶 Diaper",
     "💩 Poopy Diaper",
     "💊 Vitamin D",
+    "😴 Nap",
     "⚖️ Weight",
     "📏 Length",
 ]

--- a/page_1.py
+++ b/page_1.py
@@ -8,6 +8,7 @@ from constants import ACTIVITIES
 from utils import store_df_to_blob
 from streamlit_extras.let_it_rain import rain
 
+
 def app():
     # Define the timezone for Amsterdam
     timezone = pytz.timezone("Europe/Amsterdam")
@@ -20,9 +21,7 @@ def app():
 
     # Record Activity
     activity = activity = st.selectbox("Activity", options=ACTIVITIES)
-    amount = np.nan
-    weight = np.nan
-    length = np.nan
+    amount = weight = length = nap_time = np.nan
     # Record Amount (optional)
     if activity == "🍼 Drink":
         amount = st.number_input(
@@ -38,27 +37,31 @@ def app():
         else:
             rain = False
 
-    # Record Weight (optional)
+    # Record Weight, Length and Naptime
     if activity == "⚖️ Weight":
         weight = st.number_input("Weight (kg)", step=0.1, format="%.2f")
 
-    # Record Length (optional)
     if activity == "📏 Length":
         length = st.number_input("Length (cm)", step=0.1, format="%.2f")
+
+    if activity == "😴 Nap":
+        nap_end = datetime.combine(date, st.time_input("Nap End", value="now"))
+        nap_time = (nap_end - date_time).total_seconds() / 60
 
     # Submit button
     if st.button("Submit"):
         numbers = [i for i in [amount, weight, length] if ~np.isnan(i)]
-        store_df_to_blob(date_time, activity, amount, weight, length)
+        store_df_to_blob(date_time, activity, amount, weight, length, nap_time)
 
         if len(numbers) > 0:
             st.success(
                 f"#### Recorded: {activity} of {numbers[0]} on {date_time} to Azure 📊"
             )
-            if rain == True:
+            if rain:
                 rain_darts()
         else:
             st.success(f"#### Recorded: {activity} on {date_time} to Azure 📊")
+
 
 def rain_darts():
     rain(

--- a/page_2.py
+++ b/page_2.py
@@ -56,7 +56,9 @@ def app():
     st.subheader("Most recent activities")
     last_events = (
         df.sort_values(by="Date-Time")
-        .query("Activity in ['💩 Poopy Diaper','👶 Diaper','🍼 Drink', '💊 Vitamin D']")
+        .query(
+            "Activity in ['💩 Poopy Diaper','👶 Diaper','🍼 Drink', '💊 Vitamin D', '😴 Nap']"
+        )
         .groupby("Activity")
         .tail(1)
         .drop(["Date", "Weight", "Length"], axis=1)

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import datetime, timedelta
 from io import StringIO
 
 import pandas as pd
@@ -43,7 +43,12 @@ def upload_dataframe_to_blob(df, blob_name="history.csv"):
 
 
 def store_df_to_blob(
-    date_time: datetime, activity: str, amount: int, weight: float, length: int
+    date_time: datetime,
+    activity: str,
+    amount: int,
+    weight: float,
+    length: int,
+    nap_time: timedelta,
 ) -> pd.DataFrame:
     """Append the data to the history csv file."""
     df_hist = read_files_from_blob()
@@ -54,6 +59,7 @@ def store_df_to_blob(
         "Date-Time": [date_time],
         "Activity": [activity],
         "Amount Consumed": [amount if amount > 0 else None],
+        "Nap Time": [nap_time if nap_time else None],
         "Weight": [weight if weight > 0 else None],
         "Length": [length if length > 0 else None],
     }


### PR DESCRIPTION
Small change to add nap time registration (in minutes).

It takes the activity date/time as a starting point, an end-date selector pops when nap time activity is selected.